### PR TITLE
Add minimal email sequence index page

### DIFF
--- a/app/Http/Controllers/EmailSequencesController.php
+++ b/app/Http/Controllers/EmailSequencesController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\EmailSequence;
+use Illuminate\Contracts\View\View;
+use Sendportal\Base\Facades\Sendportal;
+
+class EmailSequencesController extends Controller
+{
+    public function index(): View
+    {
+        $sequences = EmailSequence::where('workspace_id', Sendportal::currentWorkspaceId())->get();
+
+        return view('sequences.index', compact('sequences'));
+    }
+}

--- a/resources/views/sequences/index.blade.php
+++ b/resources/views/sequences/index.blade.php
@@ -1,0 +1,36 @@
+@extends('sendportal::layouts.app')
+
+@section('heading')
+    {{ __('Email Sequences') }}
+@endsection
+
+@section('content')
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="card-table table-responsive">
+                <table class="table">
+                    <thead>
+                    <tr>
+                        <th>{{ __('Name') }}</th>
+                        <th>{{ __('Emails') }}</th>
+                        <th>{{ __('Active Subscribers') }}</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @forelse($sequences as $sequence)
+                        <tr>
+                            <td>{{ $sequence->name }}</td>
+                            <td>{{ $sequence->total_emails }}</td>
+                            <td>{{ $sequence->active_subscribers_count }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="3" class="text-center">{{ __('No email sequences found.') }}</td>
+                        </tr>
+                    @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Sendportal\Base\Facades\Sendportal;
+use App\Http\Controllers\EmailSequencesController;
 
 Auth::routes(
     [
@@ -106,8 +107,9 @@ Route::namespace('Workspaces')->middleware(
 );
 
 Route::middleware(['auth', 'verified', RequireWorkspace::class])->group(
-    static function () {      
+    static function () {
         Sendportal::webRoutes();
+        Route::get('sequences', [EmailSequencesController::class, 'index'])->name('sequences.index');
     }
 );
 


### PR DESCRIPTION
## Summary
- define `EmailSequencesController` with index action
- add `sequences.index` route
- create a basic view listing email sequences

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6842902b4ac8832d9d47a91dc904d39f