### PR TITLE
Implement tag-based sequence enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ SendPortal includes subscriber and list management, email campaigns, message tra
 
 SendPortal integrates with [Amazon SES](https://aws.amazon.com/ses), [Postmark](https://postmarkapp.com), [Sendgrid](https://sendgrid.com), [Mailgun](https://www.mailgun.com/) and [Mailjet](https://www.mailjet.com).
 
+## Email Sequences
+SendPortal includes lightweight drip sequences using existing campaigns, templates and subscriber tags. When a subscriber receives a tag linked to a sequence they are automatically enrolled. The default schedule sends an opening email immediately, a follow-up two days later and a final email five days after that.
+
 The [SendPortal](https://github.com/mettle/sendportal) application acts as a wrapper around SendPortal Core. This will allow you to run your own copy of SendPortal as a stand-alone application, including user authentication and multiple workspaces.
 
 ## Installation

--- a/app/Console/Commands/EnrollTaggedSubscribers.php
+++ b/app/Console/Commands/EnrollTaggedSubscribers.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use App\Models\TagEmailSequence;
+use App\Models\SubscriberSequence;
+
+class EnrollTaggedSubscribers extends Command
+{
+    protected $signature = 'sequences:enroll';
+    protected $description = 'Enroll tagged subscribers into email sequences';
+
+    public function handle()
+    {
+        $this->info('Processing tag-based sequence enrollments');
+
+        TagEmailSequence::with('emailSequence')->chunk(100, function ($mappings) {
+            foreach ($mappings as $mapping) {
+                if (!$mapping->emailSequence) {
+                    continue;
+                }
+
+                $subscriberIds = DB::table('sendportal_tag_subscriber')
+                    ->where('tag_id', $mapping->tag_id)
+                    ->pluck('subscriber_id');
+
+                foreach ($subscriberIds as $subscriberId) {
+                    $exists = SubscriberSequence::where('subscriber_id', $subscriberId)
+                        ->where('email_sequence_id', $mapping->email_sequence_id)
+                        ->exists();
+
+                    if (!$exists) {
+                        $mapping->emailSequence->addSubscriber($subscriberId);
+                        $this->info("Enrolled subscriber {$subscriberId} in sequence {$mapping->email_sequence_id}");
+                    }
+                }
+            }
+        });
+
+        $this->info('Enrollment processing complete');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,6 +27,7 @@ class Kernel extends ConsoleKernel
             \Log::info('✅ Cron test ran at: ' . now());
         })->everyMinute();
         $schedule->command('sequences:process')->everyFiveMinutes();
+        $schedule->command('sequences:enroll')->everyFiveMinutes();
     }
 
     /**

--- a/app/Models/TagEmailSequence.php
+++ b/app/Models/TagEmailSequence.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TagEmailSequence extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tag_id',
+        'email_sequence_id',
+    ];
+
+    public function tag(): BelongsTo
+    {
+        return $this->belongsTo(\Sendportal\Base\Models\Tag::class);
+    }
+
+    public function emailSequence(): BelongsTo
+    {
+        return $this->belongsTo(EmailSequence::class);
+    }
+}

--- a/database/migrations/2025_06_03_163150_create_tag_email_sequences_table.php
+++ b/database/migrations/2025_06_03_163150_create_tag_email_sequences_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('tag_email_sequences', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('tag_id');
+            $table->foreignId('email_sequence_id')->constrained('email_sequences')->onDelete('cascade');
+            $table->timestamps();
+
+            $table->unique(['tag_id', 'email_sequence_id']);
+            $table->foreign('tag_id')->references('id')->on('sendportal_tags')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('tag_email_sequences');
+    }
+};


### PR DESCRIPTION
## Summary
- create `TagEmailSequence` model and migration
- add console command to enroll tagged subscribers into sequences
- schedule enrollment command
- document email sequences in README

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68429673ac28832d9f2a6cb3f7dd3f9b