### PR TITLE
Add emails under sequences on index

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ SendPortal includes subscriber and list management, email campaigns, message tra
 
 SendPortal integrates with [Amazon SES](https://aws.amazon.com/ses), [Postmark](https://postmarkapp.com), [Sendgrid](https://sendgrid.com), [Mailgun](https://www.mailgun.com/) and [Mailjet](https://www.mailjet.com).
 
+## Email Sequences
+SendPortal includes lightweight drip sequences using existing campaigns, templates and subscriber tags. When a subscriber receives a tag linked to a sequence they are automatically enrolled. The default schedule sends an opening email immediately, a follow-up two days later and a final email five days after that.
+Administrators can manage sequences in the UI where each sequence is associated with a trigger tag and a set of email steps.
+
 The [SendPortal](https://github.com/mettle/sendportal) application acts as a wrapper around SendPortal Core. This will allow you to run your own copy of SendPortal as a stand-alone application, including user authentication and multiple workspaces.
 
 ## Installation

--- a/app/Console/Commands/EnrollTaggedSubscribers.php
+++ b/app/Console/Commands/EnrollTaggedSubscribers.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use App\Models\TagEmailSequence;
+use App\Models\SubscriberSequence;
+
+class EnrollTaggedSubscribers extends Command
+{
+    protected $signature = 'sequences:enroll';
+    protected $description = 'Enroll tagged subscribers into email sequences';
+
+    public function handle()
+    {
+        $this->info('Processing tag-based sequence enrollments');
+
+        TagEmailSequence::with('emailSequence')->chunk(100, function ($mappings) {
+            foreach ($mappings as $mapping) {
+                if (!$mapping->emailSequence) {
+                    continue;
+                }
+
+                $subscriberIds = DB::table('sendportal_tag_subscriber')
+                    ->where('tag_id', $mapping->tag_id)
+                    ->pluck('subscriber_id');
+
+                foreach ($subscriberIds as $subscriberId) {
+                    $exists = SubscriberSequence::where('subscriber_id', $subscriberId)
+                        ->where('email_sequence_id', $mapping->email_sequence_id)
+                        ->exists();
+
+                    if (!$exists) {
+                        $mapping->emailSequence->addSubscriber($subscriberId);
+                        $this->info("Enrolled subscriber {$subscriberId} in sequence {$mapping->email_sequence_id}");
+                    }
+                }
+            }
+        });
+
+        $this->info('Enrollment processing complete');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,6 +27,7 @@ class Kernel extends ConsoleKernel
             \Log::info('✅ Cron test ran at: ' . now());
         })->everyMinute();
         $schedule->command('sequences:process')->everyFiveMinutes();
+        $schedule->command('sequences:enroll')->everyFiveMinutes();
     }
 
     /**

--- a/app/Http/Controllers/EmailSequencesController.php
+++ b/app/Http/Controllers/EmailSequencesController.php
@@ -5,15 +5,120 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\EmailSequence;
+use App\Models\SequenceEmail;
+use App\Models\TagEmailSequence;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Sendportal\Base\Facades\Sendportal;
+use Sendportal\Base\Models\Tag;
+use Sendportal\Base\Models\Template;
 
 class EmailSequencesController extends Controller
 {
     public function index(): View
     {
-        $sequences = EmailSequence::where('workspace_id', Sendportal::currentWorkspaceId())->get();
+        $sequences = EmailSequence::with(['tagMapping.tag', 'emails.template'])
+            ->where('workspace_id', Sendportal::currentWorkspaceId())
+            ->get();
 
         return view('sequences.index', compact('sequences'));
+    }
+
+    public function create(): View
+    {
+        $tags = Tag::pluck('name', 'id');
+
+        return view('sequences.create', [
+            'tags' => $tags,
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+            'tag_id' => ['required', 'integer'],
+            'is_active' => ['sometimes', 'boolean'],
+        ]);
+
+        $sequence = EmailSequence::create([
+            'workspace_id' => Sendportal::currentWorkspaceId(),
+            'name' => $data['name'],
+            'is_active' => $request->boolean('is_active'),
+        ]);
+
+        TagEmailSequence::create([
+            'tag_id' => $data['tag_id'],
+            'email_sequence_id' => $sequence->id,
+        ]);
+
+        return redirect()->route('sequences.edit', $sequence);
+    }
+
+    public function edit(EmailSequence $sequence): View
+    {
+        $sequence->load(['emails', 'tagMapping.tag']);
+        $tags = Tag::pluck('name', 'id');
+        $templates = Template::pluck('name', 'id');
+
+        return view('sequences.edit', [
+            'sequence' => $sequence,
+            'tags' => $tags,
+            'templates' => $templates,
+        ]);
+    }
+
+    public function update(Request $request, EmailSequence $sequence): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+            'tag_id' => ['required', 'integer'],
+            'is_active' => ['sometimes', 'boolean'],
+        ]);
+
+        $sequence->update([
+            'name' => $data['name'],
+            'is_active' => $request->boolean('is_active'),
+        ]);
+
+        TagEmailSequence::updateOrCreate(
+            ['email_sequence_id' => $sequence->id],
+            ['tag_id' => $data['tag_id']]
+        );
+
+        return redirect()->route('sequences.edit', $sequence);
+    }
+
+    public function destroy(EmailSequence $sequence): RedirectResponse
+    {
+        $sequence->delete();
+
+        return redirect()->route('sequences.index');
+    }
+
+    public function storeStep(Request $request, EmailSequence $sequence): RedirectResponse
+    {
+        $data = $request->validate([
+            'subject' => ['required', 'string'],
+            'send_order' => ['required', 'integer', 'min:1'],
+            'delay_days' => ['required', 'integer', 'min:0'],
+            'template_id' => ['nullable', 'integer'],
+        ]);
+
+        $sequence->emails()->create($data);
+
+        return redirect()->route('sequences.edit', $sequence);
+    }
+
+    public function destroyStep(EmailSequence $sequence, SequenceEmail $step): RedirectResponse
+    {
+        if ($step->email_sequence_id !== $sequence->id) {
+            abort(404);
+        }
+
+        $step->delete();
+
+        return redirect()->route('sequences.edit', $sequence);
     }
 }

--- a/app/Models/EmailSequence.php
+++ b/app/Models/EmailSequence.php
@@ -6,7 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Models\TagEmailSequence;
 
 class EmailSequence extends Model
 {
@@ -55,6 +57,11 @@ class EmailSequence extends Model
     public function activeSubscriberSequences(): HasMany
     {
         return $this->subscriberSequences()->where('status', 'active');
+    }
+
+    public function tagMapping(): HasOne
+    {
+        return $this->hasOne(TagEmailSequence::class);
     }
 
     /**

--- a/app/Models/TagEmailSequence.php
+++ b/app/Models/TagEmailSequence.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TagEmailSequence extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tag_id',
+        'email_sequence_id',
+    ];
+
+    public function tag(): BelongsTo
+    {
+        return $this->belongsTo(\Sendportal\Base\Models\Tag::class);
+    }
+
+    public function emailSequence(): BelongsTo
+    {
+        return $this->belongsTo(EmailSequence::class);
+    }
+}

--- a/database/migrations/2025_06_03_163150_create_tag_email_sequences_table.php
+++ b/database/migrations/2025_06_03_163150_create_tag_email_sequences_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('tag_email_sequences', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('tag_id');
+            $table->foreignId('email_sequence_id')->constrained('email_sequences')->onDelete('cascade');
+            $table->timestamps();
+
+            $table->unique(['tag_id', 'email_sequence_id']);
+            $table->foreign('tag_id')->references('id')->on('sendportal_tags')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('tag_email_sequences');
+    }
+};

--- a/resources/views/sequences/create.blade.php
+++ b/resources/views/sequences/create.blade.php
@@ -1,0 +1,22 @@
+@extends('sendportal::layouts.app')
+
+@section('heading')
+    {{ __('Create Sequence') }}
+@endsection
+
+@section('content')
+    <div class="row">
+        <div class="col-lg-8 offset-lg-2">
+            <div class="card">
+                <div class="card-header">{{ __('Sequence Settings') }}</div>
+                <div class="card-body">
+                    <form action="{{ route('sequences.store') }}" method="post">
+                        @csrf
+                        @include('sequences.form', ['sequence' => new \App\Models\EmailSequence(), 'selectedTagId' => null])
+                        <input type="submit" class="btn btn-sm btn-primary" value="{{ __('Save') }}">
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/sequences/edit.blade.php
+++ b/resources/views/sequences/edit.blade.php
@@ -1,0 +1,87 @@
+@extends('sendportal::layouts.app')
+
+@section('heading')
+    {{ __('Edit Sequence') }}
+@endsection
+
+@section('content')
+    <div class="row">
+        <div class="col-lg-8 offset-lg-2">
+            <div class="card mb-3">
+                <div class="card-header">{{ __('Sequence Settings') }}</div>
+                <div class="card-body">
+                    <form action="{{ route('sequences.update', $sequence) }}" method="post">
+                        @csrf
+                        @method('PUT')
+                        @include('sequences.form', ['sequence' => $sequence, 'selectedTagId' => $sequence->tagMapping?->tag_id])
+                        <input type="submit" class="btn btn-sm btn-primary" value="{{ __('Save') }}">
+                    </form>
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-header">{{ __('Email Steps') }}</div>
+                <div class="card-table table-responsive">
+                    <table class="table">
+                        <thead>
+                        <tr>
+                            <th>{{ __('Subject') }}</th>
+                            <th>{{ __('Delay Days') }}</th>
+                            <th>{{ __('Template') }}</th>
+                            <th>{{ __('Order') }}</th>
+                            <th>&nbsp;</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($sequence->emails as $email)
+                            <tr>
+                                <td>{{ $email->subject }}</td>
+                                <td>{{ $email->delay_days }}</td>
+                                <td>{{ optional($email->template)->name }}</td>
+                                <td>{{ $email->send_order }}</td>
+                                <td class="td-fit">
+                                    <form action="{{ route('sequences.steps.destroy', [$sequence, $email]) }}" method="post" style="display:inline-block;">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('{{ __('Remove this step?') }}')">{{ __('Remove') }}</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-header">{{ __('Add Email Step') }}</div>
+                <div class="card-body">
+                    <form action="{{ route('sequences.steps.store', $sequence) }}" method="post">
+                        @csrf
+                        <div class="form-group">
+                            <label for="subject">{{ __('Email Subject') }}</label>
+                            <input type="text" id="subject" name="subject" class="form-control">
+                        </div>
+                        <div class="form-group">
+                            <label for="send_order">{{ __('Send Order') }}</label>
+                            <input type="number" id="send_order" name="send_order" class="form-control" min="1" value="{{ $sequence->emails->count() + 1 }}">
+                        </div>
+                        <div class="form-group">
+                            <label for="delay_days">{{ __('Delay in Days') }}</label>
+                            <input type="number" id="delay_days" name="delay_days" class="form-control" min="0" value="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="template_id">{{ __('Select Template') }}</label>
+                            <select id="template_id" name="template_id" class="form-control">
+                                @foreach($templates as $id => $name)
+                                    <option value="{{ $id }}">{{ $name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <input type="submit" class="btn btn-sm btn-primary" value="{{ __('Save') }}">
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/sequences/form.blade.php
+++ b/resources/views/sequences/form.blade.php
@@ -1,0 +1,22 @@
+<div class="form-group row">
+    <label class="col-md-3 col-form-label" for="name">{{ __('Sequence Name') }}</label>
+    <div class="col-md-7">
+        <input type="text" id="name" name="name" class="form-control" value="{{ old('name', $sequence->name ?? '') }}">
+    </div>
+</div>
+<div class="form-group row">
+    <label class="col-md-3 col-form-label" for="tag_id">{{ __('Trigger Tag') }}</label>
+    <div class="col-md-7">
+        <select id="tag_id" name="tag_id" class="form-control">
+            @foreach($tags as $id => $name)
+                <option value="{{ $id }}" {{ (old('tag_id', $selectedTagId ?? null) == $id) ? 'selected' : '' }}>{{ $name }}</option>
+            @endforeach
+        </select>
+    </div>
+</div>
+<div class="form-group row">
+    <label class="col-md-3 col-form-label" for="is_active">{{ __('Active') }}</label>
+    <div class="col-md-7">
+        <input type="checkbox" id="is_active" name="is_active" value="1" {{ old('is_active', $sequence->is_active ?? false) ? 'checked' : '' }}>
+    </div>
+</div>

--- a/resources/views/sequences/index.blade.php
+++ b/resources/views/sequences/index.blade.php
@@ -5,6 +5,10 @@
 @endsection
 
 @section('content')
+    <div class="mb-3">
+        <a href="{{ route('sequences.create') }}" class="btn btn-primary btn-sm">+ {{ __('Create Sequence') }}</a>
+    </div>
+
     <div class="row">
         <div class="col-lg-12">
             <div class="card-table table-responsive">
@@ -12,20 +16,48 @@
                     <thead>
                     <tr>
                         <th>{{ __('Name') }}</th>
+                        <th>{{ __('Trigger Tag') }}</th>
                         <th>{{ __('Emails') }}</th>
-                        <th>{{ __('Active Subscribers') }}</th>
+                        <th>{{ __('Status') }}</th>
+                        <th>&nbsp;</th>
                     </tr>
                     </thead>
                     <tbody>
                     @forelse($sequences as $sequence)
                         <tr>
                             <td>{{ $sequence->name }}</td>
+                            <td>{{ $sequence->tagMapping?->tag?->name }}</td>
                             <td>{{ $sequence->total_emails }}</td>
-                            <td>{{ $sequence->active_subscribers_count }}</td>
+                            <td>{{ $sequence->is_active ? __('Active') : __('Inactive') }}</td>
+                            <td class="td-fit">
+                                <a href="{{ route('sequences.edit', $sequence) }}" class="btn btn-light btn-sm">{{ __('Edit') }}</a>
+                                <form action="{{ route('sequences.destroy', $sequence) }}" method="post" style="display:inline-block;">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('{{ __('Delete this sequence?') }}')">{{ __('Delete') }}</button>
+                                </form>
+                            </td>
                         </tr>
+                        @if($sequence->emails->count())
+                            <tr>
+                                <td colspan="5">
+                                    <ul class="mb-0">
+                                        @foreach($sequence->emails as $email)
+                                            <li>
+                                                {{ $email->send_order }}. {{ $email->subject }}
+                                                ({{ __('Delay') }}: {{ $email->delay_days }} {{ __('days') }})
+                                                @if($email->template)
+                                                    - {{ $email->template->name }}
+                                                @endif
+                                            </li>
+                                        @endforeach
+                                    </ul>
+                                </td>
+                            </tr>
+                        @endif
                     @empty
                         <tr>
-                            <td colspan="3" class="text-center">{{ __('No email sequences found.') }}</td>
+                            <td colspan="5" class="text-center">{{ __('No email sequences found.') }}</td>
                         </tr>
                     @endforelse
                     </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -109,7 +109,9 @@ Route::namespace('Workspaces')->middleware(
 Route::middleware(['auth', 'verified', RequireWorkspace::class])->group(
     static function () {
         Sendportal::webRoutes();
-        Route::get('sequences', [EmailSequencesController::class, 'index'])->name('sequences.index');
+        Route::resource('sequences', EmailSequencesController::class)->except(['show']);
+        Route::post('sequences/{sequence}/steps', [EmailSequencesController::class, 'storeStep'])->name('sequences.steps.store');
+        Route::delete('sequences/{sequence}/steps/{step}', [EmailSequencesController::class, 'destroyStep'])->name('sequences.steps.destroy');
     }
 );
 


### PR DESCRIPTION
## Summary
- load sequence emails in controller
- show sequence emails beneath each sequence on the index page

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68429673ac28832d9f2a6cb3f7dd3f9b